### PR TITLE
Reported test duration is incorrect on some platforms

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -129,7 +129,7 @@ def analyze(res):
    print "Aggregate results (WebSocket Opening+Closing Handshake)"
    print
    #print "          Duration: %9d ms" % (float(res.duration) / 1000.)
-   print "          Duration: %9.1f s" % round(duration_ms, 1)
+   print "          Duration: %9.1f ms" % round(duration_ms, 1)
    print "             Total: %9d" % res.total
    print "           Success: %9d" % res.success
    print "              Fail: %9d" % res.fail

--- a/wsperf.cpp
+++ b/wsperf.cpp
@@ -204,6 +204,8 @@ public:
     }
 
     void test_complete() {
+        using std::chrono::nanoseconds;
+
         m_test_end = std::chrono::high_resolution_clock::now();
         m_test_end_wallclock = std::chrono::system_clock::now();
 
@@ -212,8 +214,10 @@ public:
 
         logfile << "{\"total_duration\":"
                 << std::chrono::duration_cast<dur_type>(m_test_end-m_test_start).count()
-                << ",\"started\":" << m_test_start_wallclock.time_since_epoch().count()
-                << ",\"ended\":" << m_test_end_wallclock.time_since_epoch().count()
+                << ",\"started\":"
+                << std::chrono::duration_cast<nanoseconds>(m_test_start_wallclock.time_since_epoch()).count()
+                << ",\"ended\":"
+                << std::chrono::duration_cast<nanoseconds>(m_test_end_wallclock.time_since_epoch()).count()
                 << ",\"handshake_throttle_count\":" << m_high_water_mark_count
                 << ",\"handshake_resume_count\":" << m_low_water_mark_count
                 << ",\"connection_stats\":[";


### PR DESCRIPTION
analyze.py seems to assume the start and end times in the JSON report are in nanoseconds, but `std::chrono::system_clock`'s duration can differ per-system and wsperf doesn't explicitly convert to any unit of time. I've attached a pull request, which `duration_cast`s the times for consistency.
